### PR TITLE
Arbitrary topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ PING/PONG messages are also handled internally.
 ### Subprotocol registry
 An API is provided to create subprotocols and register messages to them.
 
-### Message registry
-This library requires you to define incoming/outgoing messages, allowing the WebSocket Server to assign an 8bit
-code to each message for better efficiency. Messages are byte arrays, so you can use any encoder/decoder you like.
+### Message encoding
+Message names (topics) are strings with a maximum length of 225 bytes, and the payload is a byte array. You can use any
+encoder/decoder you like as long as you can decode/encode it at the client.
 
 ### Socket management
 Socket operations are handled internally with sane defaults. There is an optional `ClientID` function that will run on

--- a/examples/scratch.go
+++ b/examples/scratch.go
@@ -9,25 +9,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	MsgExploreCommand = websocket.Message("explore")
-	MsgFlagCommand    = websocket.Message("flag")
-	MsgStateRequest   = websocket.Message("state_request")
-
-	MsgStateResponse = websocket.Message("state")
-)
-
 func main() {
 	ws := websocket.NewWebSocketServer()
 	ws.SetLogger(logrus.WithField("component", "websocket"))
 	wsAPI := &WebSocketAPI{}
 
 	subp := ws.Subprotocol("com.dowuz.minesweeper.api-v1")
-	subp.RegisterReceiver(MsgExploreCommand, wsAPI.HandleExplore)
-	subp.RegisterReceiver(MsgFlagCommand, wsAPI.HandleFlag)
-	subp.RegisterReceiver(MsgStateRequest, wsAPI.HandleStateRequest)
-
-	subp.RegisterSender(MsgStateResponse)
+	subp.Handle("explore", wsAPI.HandleExplore)
+	subp.Handle("flag", wsAPI.HandleFlag)
+	subp.Handle("state", wsAPI.HandleStateRequest)
 
 	http.Handle("/ws", ws)
 	_ = http.ListenAndServe(":8080", nil)
@@ -47,7 +37,7 @@ func (p WebSocketAPI) HandleExplore(socket *websocket.Socket, msg []byte) {
 	res := map[string]interface{}{}
 	response, _ := json.Marshal(res)
 
-	_ = socket.Send(MsgStateResponse, response)
+	_ = socket.Send("state", response)
 }
 
 func (p WebSocketAPI) HandleFlag(socket *websocket.Socket, msg []byte) {
@@ -62,7 +52,7 @@ func (p WebSocketAPI) HandleFlag(socket *websocket.Socket, msg []byte) {
 	res := map[string]interface{}{}
 	response, _ := json.Marshal(res)
 
-	_ = socket.Send(MsgStateResponse, response)
+	_ = socket.Send("state", response)
 }
 
 func (p WebSocketAPI) HandleStateRequest(socket *websocket.Socket, msg []byte) {
@@ -76,7 +66,7 @@ func (p WebSocketAPI) HandleStateRequest(socket *websocket.Socket, msg []byte) {
 	res := map[string]interface{}{}
 	response, _ := json.Marshal(res)
 
-	_ = socket.Send(MsgStateResponse, response)
+	_ = socket.Send("state", response)
 }
 
 type ActionCommand struct {

--- a/payload_test.go
+++ b/payload_test.go
@@ -1,0 +1,29 @@
+package websocket
+
+import "testing"
+
+func BenchmarkPayloadAppend(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var payload = []byte{99, 99, 99, 99}
+		var message = "message_of_some_size"
+		var msgLen = uint8(len(message))
+
+		payload = append(payload, []byte(string(msgLen)+message)...)
+		copy(payload[msgLen+1:], payload)
+		copy(payload[1:], message)
+		payload[0] = msgLen
+	}
+}
+
+func BenchmarkPayloadNewSlice(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var payload = []byte{99, 99, 99, 99}
+		var message = "message_of_some_size"
+		var msgLen = uint8(len(message))
+
+		newPayload := make([]byte, len(payload)+len(message)+1)
+		copy(newPayload[msgLen+1:], payload)
+		copy(newPayload[1:], message)
+		newPayload[0] = msgLen
+	}
+}

--- a/socket.go
+++ b/socket.go
@@ -125,11 +125,11 @@ func (s *Socket) Close() error {
 }
 
 // Send is a helper method to send a message to current socket
-func (s *Socket) Send(message string, payload []byte) error {
-	return s.subp.SendToSocket(s, message, payload)
+func (s *Socket) Send(topic string, payload []byte) error {
+	return s.subp.SendToSocket(s, topic, payload)
 }
 
 // SendToClient is a helper method to send a message to all sockets of the same client
-func (s *Socket) SendToClient(message string, payload []byte) error {
-	return s.subp.SendToClient(s.clientID, message, payload)
+func (s *Socket) SendToClient(topic string, payload []byte) error {
+	return s.subp.SendToClient(s.clientID, topic, payload)
 }

--- a/socket.go
+++ b/socket.go
@@ -40,14 +40,8 @@ func NewSocket(conn *websocket.Conn, subp *Subprotocol, log *logrus.Entry) *Sock
 }
 
 // send queues the message to be sent
-func (s *Socket) send(message messageCode, payload []byte) {
-	// Prepend message code to payload
-	payload = append(payload, 0)
-	copy(payload[1:], payload)
-	payload[0] = byte(message)
-
-	// Queue the message to be sent
-	s.sendQueue <- payload
+func (s *Socket) send(msg []byte) {
+	s.sendQueue <- msg
 }
 
 func (s *Socket) readPump() {
@@ -131,11 +125,11 @@ func (s *Socket) Close() error {
 }
 
 // Send is a helper method to send a message to current socket
-func (s *Socket) Send(message Message, payload []byte) error {
+func (s *Socket) Send(message string, payload []byte) error {
 	return s.subp.SendToSocket(s, message, payload)
 }
 
 // SendToClient is a helper method to send a message to all sockets of the same client
-func (s *Socket) SendToClient(message Message, payload []byte) error {
+func (s *Socket) SendToClient(message string, payload []byte) error {
 	return s.subp.SendToClient(s.clientID, message, payload)
 }


### PR DESCRIPTION
This PR implements a new encoding method that enables sending/receiving messages with arbitrary names (topics), therefore removing the message registry and lifting the upper limit of 255 incoming and 255 outgoing messages that the old method imposed.